### PR TITLE
docs: add .env.example for environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Tenshu Environment Configuration
+# Copy this file to .env and adjust values for your setup.
+# Do NOT commit your actual .env file.
+
+# ── Server ──────────────────────────────────────────────
+
+# Port for the Tenshu server (default: 3001)
+# TENSHU_PORT=3001
+
+# Path to your OpenClaw installation directory (default: ~/.openclaw)
+# OPENCLAW_DIR=~/.openclaw
+
+# ── Data Sources ────────────────────────────────────────
+
+# Path to the team results TSV file
+# (default: ~/clawd/team/knowledge/results.tsv)
+# RESULTS_TSV=~/clawd/team/knowledge/results.tsv
+
+# Path to the team directory for activity and notifications
+# (default: ~/clawd/team)
+# TEAM_DIR=~/clawd/team

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,10 @@ cd tenshu
 # Install all dependencies (workspaces are linked automatically)
 npm install
 
+# (Optional) Configure environment variables
+cp .env.example .env
+# Edit .env to match your setup — see .env.example for available variables
+
 # Start both client and server in dev mode
 npm run dev
 ```


### PR DESCRIPTION
Fixes #6

Added `.env.example` with all environment variables (TENSHU_PORT, OPENCLAW_DIR, RESULTS_TSV, TEAM_DIR) and updated CONTRIBUTING.md setup steps.