### PR TITLE
test: clarify makeAgent id derivation and add rel assertion

### DIFF
--- a/client/src/__tests__/DemoBanner.test.tsx
+++ b/client/src/__tests__/DemoBanner.test.tsx
@@ -32,5 +32,6 @@ describe('DemoBanner', () => {
       'https://github.com/JesseRWeigel/tenshu',
     )
     expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer')
   })
 })

--- a/client/src/__tests__/helpers.tsx
+++ b/client/src/__tests__/helpers.tsx
@@ -50,15 +50,16 @@ export function makeAgent(overrides?: {
   color?: string
   emoji?: string
 }): Agent {
+  const configId = overrides?.config?.id ?? 'test-agent'
   return {
     config: {
-      id: 'test-agent',
+      id: configId,
       name: 'Test Agent',
       workspace: '/tmp/test',
       ...overrides?.config,
     },
     state: {
-      id: overrides?.config?.id ?? 'test-agent',
+      id: configId,
       status: 'idle',
       ...overrides?.state,
     },


### PR DESCRIPTION
## Changes

Two small test improvements from the PR #9 review follow-ups:

### 1. Clarify makeAgent helper id derivation (fixes #11)

Extracts `configId` into a local variable so the `config.id → state.id` relationship is immediately obvious. Previously the inline expression `overrides?.config?.id ?? 'test-agent'` made it easy to miss that `state.id` was derived from the config override.

### 2. Add `rel="noopener noreferrer"` assertion (fixes #10)

The DemoBanner component correctly sets `rel="noopener noreferrer"` on the GitHub link, but the test didn't assert it. Added the assertion to prevent accidental removal of this security attribute.

### Testing

All 46 client tests pass. No changes to source code — test files only.