### PR TITLE
test(routes): add unit tests for remaining route handlers (closes #44)

### DIFF
--- a/server/src/__tests__/interactions.test.ts
+++ b/server/src/__tests__/interactions.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Hono } from 'hono'
+
+const TEST_DIR = join(tmpdir(), 'tenshu-test-interactions')
+const TEST_KNOWLEDGE_DIR = join(TEST_DIR, 'team', 'knowledge')
+const TEST_RESULTS_TSV = join(TEST_KNOWLEDGE_DIR, 'results.tsv')
+
+// Set environment before importing routes
+process.env.RESULTS_TSV = TEST_RESULTS_TSV
+
+describe('interactions routes', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    try {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+    mkdirSync(TEST_KNOWLEDGE_DIR, { recursive: true })
+
+    vi.resetModules()
+    const { default: interactionsRoute } =
+      await import('../routes/interactions.js')
+    app = new Hono()
+    app.route('/interactions', interactionsRoute)
+  })
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  describe('GET /interactions', () => {
+    it('returns empty nodes and edges when results.tsv does not exist', async () => {
+      const res = await app.request('/interactions')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.nodes).toEqual([])
+      expect(data.edges).toEqual([])
+    })
+
+    it('returns empty nodes and edges for header-only TSV', async () => {
+      writeFileSync(
+        TEST_RESULTS_TSV,
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+      )
+
+      const res = await app.request('/interactions')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.nodes).toEqual([])
+      expect(data.edges).toEqual([])
+    })
+
+    it('builds agent nodes with task counts and average scores', async () => {
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tresearcher\t7.0\tkeep\tResearched',
+        '2026-03-24T11:00:00Z\t1\ttask-a\tcoder\t8.0\tkeep\tImplemented',
+        '2026-03-24T12:00:00Z\t2\ttask-b\tresearcher\t9.0\tkeep\tResearched again',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const res = await app.request('/interactions')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      const researcher = data.nodes.find(
+        (n: { id: string }) => n.id === 'researcher',
+      )
+      expect(researcher).toBeDefined()
+      expect(researcher.name).toBe('Senku')
+      expect(researcher.role).toBe('researcher')
+      expect(researcher.tasksCompleted).toBe(2)
+      expect(researcher.avgScore).toBe(8.0)
+
+      const coder = data.nodes.find((n: { id: string }) => n.id === 'coder')
+      expect(coder).toBeDefined()
+      expect(coder.name).toBe('Bulma')
+      expect(coder.tasksCompleted).toBe(1)
+      expect(coder.avgScore).toBe(8.0)
+    })
+
+    it('maps known agent IDs to character names', async () => {
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tresearcher\t7.0\tkeep\tR',
+        '2026-03-24T11:00:00Z\t1\ttask-a\tcoder\t7.0\tkeep\tC',
+        '2026-03-24T12:00:00Z\t1\ttask-a\tqa\t7.0\tkeep\tQ',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const res = await app.request('/interactions')
+      const data = await res.json()
+
+      const names: Record<string, string> = {}
+      for (const node of data.nodes) {
+        names[node.id] = node.name
+      }
+      expect(names.researcher).toBe('Senku')
+      expect(names.coder).toBe('Bulma')
+      expect(names.qa).toBe('Vegeta')
+    })
+
+    it('uses agent ID as name for unknown agents', async () => {
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tcustom-bot\t7.0\tkeep\tCustom',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const res = await app.request('/interactions')
+      const data = await res.json()
+
+      const custom = data.nodes.find(
+        (n: { id: string }) => n.id === 'custom-bot',
+      )
+      expect(custom).toBeDefined()
+      expect(custom.name).toBe('custom-bot')
+    })
+
+    it('handles agents with zero scores', async () => {
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tresearcher\t0\tcrash\tCrashed',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const res = await app.request('/interactions')
+      const data = await res.json()
+
+      const researcher = data.nodes.find(
+        (n: { id: string }) => n.id === 'researcher',
+      )
+      expect(researcher.avgScore).toBe(0)
+    })
+
+    it('infers delegation edges from cycle agent sequences', async () => {
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tresearcher\t7.0\tkeep\tR',
+        '2026-03-24T11:00:00Z\t1\ttask-a\tcoder\t8.0\tkeep\tC',
+        '2026-03-24T12:00:00Z\t1\ttask-a\tqa\t8.0\tkeep\tQ',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const res = await app.request('/interactions')
+      const data = await res.json()
+
+      expect(data.edges.length).toBeGreaterThan(0)
+
+      const researcherToCoder = data.edges.find(
+        (e: { from: string; to: string }) =>
+          e.from === 'researcher' && e.to === 'coder',
+      )
+      expect(researcherToCoder).toBeDefined()
+      expect(researcherToCoder.count).toBe(1)
+
+      const coderToQa = data.edges.find(
+        (e: { from: string; to: string }) =>
+          e.from === 'coder' && e.to === 'qa',
+      )
+      expect(coderToQa).toBeDefined()
+    })
+
+    it('accumulates edge counts across multiple cycles', async () => {
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tresearcher\t7.0\tkeep\tR1',
+        '2026-03-24T11:00:00Z\t1\ttask-a\tcoder\t7.0\tkeep\tC1',
+        '2026-03-24T12:00:00Z\t2\ttask-b\tresearcher\t8.0\tkeep\tR2',
+        '2026-03-24T13:00:00Z\t2\ttask-b\tcoder\t8.0\tkeep\tC2',
+        '2026-03-24T14:00:00Z\t3\ttask-c\tresearcher\t9.0\tkeep\tR3',
+        '2026-03-24T15:00:00Z\t3\ttask-c\tcoder\t9.0\tkeep\tC3',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const res = await app.request('/interactions')
+      const data = await res.json()
+
+      const researcherToCoder = data.edges.find(
+        (e: { from: string; to: string }) =>
+          e.from === 'researcher' && e.to === 'coder',
+      )
+      expect(researcherToCoder).toBeDefined()
+      expect(researcherToCoder.count).toBe(3)
+    })
+
+    it('computes average score on edges', async () => {
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tresearcher\t7.0\tkeep\tR1',
+        '2026-03-24T11:00:00Z\t1\ttask-a\tcoder\t8.0\tkeep\tC1',
+        '2026-03-24T12:00:00Z\t2\ttask-b\tresearcher\t6.0\tkeep\tR2',
+        '2026-03-24T13:00:00Z\t2\ttask-b\tcoder\t10.0\tkeep\tC2',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const res = await app.request('/interactions')
+      const data = await res.json()
+
+      const edge = data.edges.find(
+        (e: { from: string; to: string }) =>
+          e.from === 'researcher' && e.to === 'coder',
+      )
+      expect(edge).toBeDefined()
+      // Final scores per cycle: cycle 1 = 8.0, cycle 2 = 10.0 => avg 9.0
+      expect(edge.avgScore).toBe(9.0)
+    })
+
+    it('tracks task names on edges (max 5)', async () => {
+      const lines = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+      ]
+      for (let i = 1; i <= 7; i++) {
+        lines.push(
+          `2026-03-24T${String(i + 9).padStart(2, '0')}:00:00Z\t${i}\ttask-${i}\tresearcher\t7.0\tkeep\tR`,
+        )
+        lines.push(
+          `2026-03-24T${String(i + 9).padStart(2, '0')}:30:00Z\t${i}\ttask-${i}\tcoder\t7.0\tkeep\tC`,
+        )
+      }
+      writeFileSync(TEST_RESULTS_TSV, lines.join('\n'))
+
+      const res = await app.request('/interactions')
+      const data = await res.json()
+
+      const edge = data.edges.find(
+        (e: { from: string; to: string }) =>
+          e.from === 'researcher' && e.to === 'coder',
+      )
+      expect(edge.tasks.length).toBeLessThanOrEqual(5)
+    })
+
+    it('handles error gracefully and returns 500', async () => {
+      // Create a directory where the file is expected to cause a read error
+      rmSync(TEST_RESULTS_TSV, { force: true })
+      mkdirSync(TEST_RESULTS_TSV, { recursive: true })
+
+      const res = await app.request('/interactions')
+      expect(res.status).toBe(500)
+      const data = await res.json()
+      expect(data.error).toBeDefined()
+    })
+  })
+})

--- a/server/src/__tests__/knowledge.test.ts
+++ b/server/src/__tests__/knowledge.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Hono } from 'hono'
+
+const TEST_DIR = join(tmpdir(), 'tenshu-test-knowledge')
+const TEST_TEAM_DIR = join(TEST_DIR, 'team')
+const TEST_ARTIFACTS_DIR = join(TEST_TEAM_DIR, 'knowledge', 'artifacts')
+
+// Set environment before importing routes
+process.env.TEAM_DIR = TEST_TEAM_DIR
+
+describe('knowledge routes', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    try {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+    mkdirSync(TEST_ARTIFACTS_DIR, { recursive: true })
+
+    vi.resetModules()
+    const { default: knowledgeRoute } = await import('../routes/knowledge.js')
+    app = new Hono()
+    app.route('/knowledge', knowledgeRoute)
+  })
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true })
+  })
+
+  describe('GET /knowledge', () => {
+    it('returns empty artifacts when directory does not exist', async () => {
+      rmSync(TEST_ARTIFACTS_DIR, { recursive: true, force: true })
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.artifacts).toEqual([])
+      expect(data.total).toBe(0)
+    })
+
+    it('returns empty artifacts for empty directory', async () => {
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.artifacts).toEqual([])
+      expect(data.total).toBe(0)
+    })
+
+    it('lists markdown artifacts with parsed metadata', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-explore-api-20260324-100000.md'),
+        '# Research\n---\nCycle: 1\nLength: 500\n\nThis is a substantive preview of the research artifact content.',
+      )
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(1)
+      expect(data.total).toBe(1)
+      expect(data.artifacts[0].name).toBe(
+        'research-explore-api-20260324-100000.md',
+      )
+      expect(data.artifacts[0].type).toBe('research')
+      expect(data.artifacts[0].task).toBe('explore-api')
+      expect(data.artifacts[0].agent).toBe('Senku')
+      expect(data.artifacts[0].timestamp).toBe('2026-03-24 10:00:00')
+      expect(data.artifacts[0].preview).toContain('substantive preview')
+    })
+
+    it('maps agent types to names (researcher=Senku, coder=Bulma, qa=Vegeta)', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task1-20260324-100000.md'),
+        '# Research\n\n\n\nThis is substantive research content here.',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'coder-task2-20260324-110000.md'),
+        '# Code\n\n\n\nThis is substantive coder content here.',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'qa-task3-20260324-120000.md'),
+        '# QA\n\n\n\nThis is substantive qa review content here.',
+      )
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(3)
+      const research = data.artifacts.find(
+        (a: { type: string }) => a.type === 'research',
+      )
+      const coder = data.artifacts.find(
+        (a: { type: string }) => a.type === 'coder',
+      )
+      const qa = data.artifacts.find((a: { type: string }) => a.type === 'qa')
+      expect(research.agent).toBe('Senku')
+      expect(coder.agent).toBe('Bulma')
+      expect(qa.agent).toBe('Vegeta')
+    })
+
+    it('handles malformed filenames as misc type', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'random-notes.md'),
+        '# Notes\n\n\n\nSome miscellaneous notes content here.',
+      )
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(1)
+      expect(data.artifacts[0].type).toBe('misc')
+      expect(data.artifacts[0].agent).toBe('unknown')
+      expect(data.artifacts[0].timestamp).toBe('')
+    })
+
+    it('ignores non-markdown files', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task-20260324-100000.md'),
+        '# Research\n\n\n\nSubstantive research content here.',
+      )
+      writeFileSync(join(TEST_ARTIFACTS_DIR, 'data.json'), '{}')
+      writeFileSync(join(TEST_ARTIFACTS_DIR, 'notes.txt'), 'text')
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(1)
+      expect(data.artifacts[0].name).toContain('.md')
+    })
+
+    it('respects the limit query parameter', async () => {
+      for (let i = 0; i < 10; i++) {
+        writeFileSync(
+          join(TEST_ARTIFACTS_DIR, `research-task${i}-20260324-10000${i}.md`),
+          `# Task ${i}\n\n\n\nSubstantive content for task number ${i} here.`,
+        )
+      }
+
+      const res = await app.request('/knowledge?limit=3')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(3)
+      expect(data.total).toBe(10)
+    })
+
+    it('defaults to limit of 50', async () => {
+      for (let i = 0; i < 55; i++) {
+        writeFileSync(
+          join(
+            TEST_ARTIFACTS_DIR,
+            `research-task${String(i).padStart(3, '0')}-20260324-100000.md`,
+          ),
+          `# Task ${i}\n\n\n\nSubstantive content for task number ${i} here.`,
+        )
+      }
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(50)
+      expect(data.total).toBe(55)
+    })
+
+    it('filters by agent query parameter', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task1-20260324-100000.md'),
+        '# Research\n\n\n\nSubstantive research content here for test.',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'coder-task2-20260324-110000.md'),
+        '# Code\n\n\n\nSubstantive coder content here for test.',
+      )
+
+      const res = await app.request('/knowledge?agent=research')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(1)
+      expect(data.artifacts[0].type).toBe('research')
+    })
+
+    it('filters by type query parameter', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task1-20260324-100000.md'),
+        '# Research\n\n\n\nSubstantive research content here for test.',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'coder-task2-20260324-110000.md'),
+        '# Code\n\n\n\nSubstantive coder content here for test.',
+      )
+
+      const res = await app.request('/knowledge?type=coder')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(1)
+      expect(data.artifacts[0].type).toBe('coder')
+    })
+
+    it('filters by search query (filename match)', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-auth-flow-20260324-100000.md'),
+        '# Research\n\n\n\nSubstantive research content here for test.',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'coder-data-pipeline-20260324-110000.md'),
+        '# Code\n\n\n\nSubstantive coder content here for test.',
+      )
+
+      const res = await app.request('/knowledge?search=auth')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(1)
+      expect(data.artifacts[0].task).toBe('auth-flow')
+    })
+
+    it('filters by search query (content match)', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task1-20260324-100000.md'),
+        '# Research\n\n\n\nThis artifact discusses authentication patterns in depth.',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'coder-task2-20260324-110000.md'),
+        '# Code\n\n\n\nThis artifact covers database migrations thoroughly.',
+      )
+
+      const res = await app.request('/knowledge?search=authentication')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts).toHaveLength(1)
+      expect(data.artifacts[0].name).toContain('task1')
+    })
+
+    it('returns artifacts in reverse sorted order', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-aaa-20260324-100000.md'),
+        '# A\n\n\n\nSubstantive content for artifact A here.',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-zzz-20260324-110000.md'),
+        '# Z\n\n\n\nSubstantive content for artifact Z here.',
+      )
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts[0].name).toContain('zzz')
+      expect(data.artifacts[1].name).toContain('aaa')
+    })
+
+    it('extracts preview skipping headers and metadata lines', async () => {
+      const content = `# Title
+## Subtitle
+---
+Cycle: 5
+Length: 200
+
+Short.
+
+This is the first substantive preview line that should be extracted from the content.`
+
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task-20260324-100000.md'),
+        content,
+      )
+
+      const res = await app.request('/knowledge')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.artifacts[0].preview).toContain(
+        'first substantive preview line',
+      )
+    })
+  })
+
+  describe('GET /knowledge/artifact/:name', () => {
+    it('returns full artifact content', async () => {
+      const content = '# Research\n\nFull content of the artifact.'
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task-20260324-100000.md'),
+        content,
+      )
+
+      const res = await app.request(
+        '/knowledge/artifact/research-task-20260324-100000.md',
+      )
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.name).toBe('research-task-20260324-100000.md')
+      expect(data.content).toBe(content)
+      expect(data.type).toBe('research')
+      expect(data.task).toBe('task')
+      expect(data.agent).toBe('Senku')
+      expect(data.timestamp).toBe('2026-03-24 10:00:00')
+      expect(data.sizeKB).toBeGreaterThanOrEqual(0)
+    })
+
+    it('returns 404 for non-existent artifact', async () => {
+      const res = await app.request('/knowledge/artifact/does-not-exist.md')
+      expect(res.status).toBe(404)
+      const data = await res.json()
+      expect(data.error).toBe('Not found')
+    })
+
+    it('returns 400 for path traversal attempts with ..', async () => {
+      const res = await app.request(
+        '/knowledge/artifact/..%2F..%2Fetc%2Fpasswd',
+      )
+      expect(res.status).toBe(400)
+      const data = await res.json()
+      expect(data.error).toBe('Invalid filename')
+    })
+
+    it('returns 400 for path traversal attempts with /', async () => {
+      const res = await app.request('/knowledge/artifact/foo%2Fbar.md')
+      expect(res.status).toBe(400)
+      const data = await res.json()
+      expect(data.error).toBe('Invalid filename')
+    })
+  })
+
+  describe('GET /knowledge/stats', () => {
+    it('returns zero stats when artifacts directory does not exist', async () => {
+      rmSync(TEST_ARTIFACTS_DIR, { recursive: true, force: true })
+
+      const res = await app.request('/knowledge/stats')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.total).toBe(0)
+      expect(data.byType).toEqual({})
+      expect(data.byAgent).toEqual({})
+    })
+
+    it('returns aggregate counts by type and agent', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task1-20260324-100000.md'),
+        '# R1\ncontent',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task2-20260324-110000.md'),
+        '# R2\ncontent',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'coder-task3-20260324-120000.md'),
+        '# C1\ncontent',
+      )
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'qa-task4-20260324-130000.md'),
+        '# Q1\ncontent',
+      )
+
+      const res = await app.request('/knowledge/stats')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.total).toBe(4)
+      expect(data.byType.research).toBe(2)
+      expect(data.byType.coder).toBe(1)
+      expect(data.byType.qa).toBe(1)
+      expect(data.byAgent.Senku).toBe(2)
+      expect(data.byAgent.Bulma).toBe(1)
+      expect(data.byAgent.Vegeta).toBe(1)
+    })
+
+    it('includes totalSizeKB in stats', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task-20260324-100000.md'),
+        'x'.repeat(2048),
+      )
+
+      const res = await app.request('/knowledge/stats')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.total).toBe(1)
+      expect(data.totalSizeKB).toBeGreaterThanOrEqual(1)
+    })
+
+    it('ignores non-markdown files in stats', async () => {
+      writeFileSync(
+        join(TEST_ARTIFACTS_DIR, 'research-task-20260324-100000.md'),
+        '# R\ncontent',
+      )
+      writeFileSync(join(TEST_ARTIFACTS_DIR, 'data.json'), '{}')
+
+      const res = await app.request('/knowledge/stats')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.total).toBe(1)
+    })
+  })
+})

--- a/server/src/__tests__/notifications.test.ts
+++ b/server/src/__tests__/notifications.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Hono } from 'hono'
+
+const TEST_DIR = join(tmpdir(), 'tenshu-test-notifications')
+const TEST_KNOWLEDGE_DIR = join(TEST_DIR, 'team', 'knowledge')
+const TEST_RESULTS_TSV = join(TEST_KNOWLEDGE_DIR, 'results.tsv')
+const TEST_ORCHESTRATOR_LOG = join(tmpdir(), 'tenshu-test-orch-notif.log')
+
+// Set environment before importing routes
+process.env.TEAM_DIR = join(TEST_DIR, 'team')
+process.env.RESULTS_TSV = TEST_RESULTS_TSV
+
+describe('notification routes', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    try {
+      rmSync(TEST_DIR, { recursive: true, force: true })
+    } catch {
+      // ignore
+    }
+    mkdirSync(TEST_KNOWLEDGE_DIR, { recursive: true })
+
+    // Clear timers to prevent the setInterval from firing
+    vi.useFakeTimers({ shouldAdvanceTime: false })
+
+    vi.resetModules()
+    const { default: notificationRoutes } =
+      await import('../routes/notifications.js')
+
+    app = new Hono()
+    app.route('/notifications', notificationRoutes)
+
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true })
+    try {
+      rmSync(TEST_ORCHESTRATOR_LOG, { force: true })
+    } catch {
+      // ignore
+    }
+  })
+
+  describe('GET /notifications', () => {
+    it('returns empty notifications initially', async () => {
+      const res = await app.request('/notifications')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.notifications).toEqual([])
+      expect(data.total).toBe(0)
+    })
+
+    it('returns notifications structure with limit and total', async () => {
+      const res = await app.request('/notifications?limit=10')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data).toHaveProperty('notifications')
+      expect(data).toHaveProperty('total')
+      expect(Array.isArray(data.notifications)).toBe(true)
+    })
+  })
+
+  describe('DELETE /notifications/:id', () => {
+    it('returns ok for deleting a non-existent notification', async () => {
+      const res = await app.request('/notifications/nonexistent-id', {
+        method: 'DELETE',
+      })
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.ok).toBe(true)
+    })
+  })
+
+  describe('scanForEvents (via module import)', () => {
+    it('generates notification for high score (>=9)', async () => {
+      // We need to test the scanning logic by triggering it
+      vi.useFakeTimers({ shouldAdvanceTime: false })
+      vi.resetModules()
+
+      // Write results TSV with a high score before importing
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\tapi-design\tresearcher\t9.5\tkeep\tExcellent work',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const { default: notifRoutes } =
+        await import('../routes/notifications.js')
+      const testApp = new Hono()
+      testApp.route('/notifications', notifRoutes)
+
+      // Wait for initial scan to complete
+      vi.useRealTimers()
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      const res = await testApp.request('/notifications')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      // The initial scanForEvents call should have detected the high score
+      const highScoreNotif = data.notifications.find(
+        (n: { title: string }) => n.title === 'High Score!',
+      )
+      expect(highScoreNotif).toBeDefined()
+      expect(highScoreNotif.level).toBe('success')
+      expect(highScoreNotif.message).toContain('9.5')
+    })
+
+    it('generates notification for agent crash', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: false })
+      vi.resetModules()
+
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t3\tauth-flow\tcoder\t0\tcrash\tSegfault',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const { default: notifRoutes } =
+        await import('../routes/notifications.js')
+      const testApp = new Hono()
+      testApp.route('/notifications', notifRoutes)
+
+      vi.useRealTimers()
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      const res = await testApp.request('/notifications')
+      const data = await res.json()
+
+      const crashNotif = data.notifications.find(
+        (n: { title: string }) => n.title === 'Agent Crash',
+      )
+      expect(crashNotif).toBeDefined()
+      expect(crashNotif.level).toBe('error')
+      expect(crashNotif.message).toContain('coder')
+    })
+
+    it('generates notification for low score (<4)', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: false })
+      vi.resetModules()
+
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t2\trefactor\tqa\t2.5\tkeep\tPoor quality',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const { default: notifRoutes } =
+        await import('../routes/notifications.js')
+      const testApp = new Hono()
+      testApp.route('/notifications', notifRoutes)
+
+      vi.useRealTimers()
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      const res = await testApp.request('/notifications')
+      const data = await res.json()
+
+      const lowScoreNotif = data.notifications.find(
+        (n: { title: string }) => n.title === 'Low Score',
+      )
+      expect(lowScoreNotif).toBeDefined()
+      expect(lowScoreNotif.level).toBe('warning')
+      expect(lowScoreNotif.message).toContain('2.5')
+    })
+
+    it('does not generate notification for mid-range scores', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: false })
+      vi.resetModules()
+
+      const tsv = [
+        'timestamp\tcycle\ttask\tagent\tscore\tstatus\tdescription',
+        '2026-03-24T10:00:00Z\t1\ttask-a\tresearcher\t6.0\tkeep\tAverage work',
+      ].join('\n')
+      writeFileSync(TEST_RESULTS_TSV, tsv)
+
+      const { default: notifRoutes } =
+        await import('../routes/notifications.js')
+      const testApp = new Hono()
+      testApp.route('/notifications', notifRoutes)
+
+      vi.useRealTimers()
+      await new Promise((resolve) => setTimeout(resolve, 200))
+
+      const res = await testApp.request('/notifications')
+      const data = await res.json()
+
+      expect(data.notifications).toHaveLength(0)
+    })
+  })
+})

--- a/server/src/__tests__/system.test.ts
+++ b/server/src/__tests__/system.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Hono } from 'hono'
+
+// We need to mock before importing the route
+const mockedReadFile = vi.fn()
+const mockedExecFile = vi.fn()
+
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => mockedReadFile(...args),
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => mockedExecFile(...args),
+}))
+
+describe('system routes', () => {
+  let app: Hono
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+
+    // Re-apply mocks after resetModules
+    vi.doMock('node:fs/promises', () => ({
+      readFile: (...args: unknown[]) => mockedReadFile(...args),
+    }))
+    vi.doMock('node:child_process', () => ({
+      execFile: (...args: unknown[]) => mockedExecFile(...args),
+    }))
+
+    const { default: systemRoute } = await import('../routes/system.js')
+    app = new Hono()
+    app.route('/system', systemRoute)
+  })
+
+  function setupProcMocks(overrides: Record<string, string> = {}) {
+    const defaults: Record<string, string> = {
+      '/proc/stat':
+        'cpu  100 20 30 800 10 5 3 0 0 0\ncpu0  50 10 15 400 5 2 1 0 0 0',
+      '/proc/cpuinfo':
+        'processor\t: 0\nmodel name\t: Test CPU\n\nprocessor\t: 1\nmodel name\t: Test CPU\n',
+      '/proc/meminfo':
+        'MemTotal:       16384000 kB\nMemFree:         1000000 kB\nMemAvailable:    8192000 kB\n',
+      '/proc/uptime': '90061.45 170000.00',
+      ...overrides,
+    }
+
+    mockedReadFile.mockImplementation(async (path: unknown) => {
+      const p = String(path)
+      if (defaults[p] !== undefined) return defaults[p]
+      throw new Error(`Unexpected readFile: ${p}`)
+    })
+  }
+
+  function setupExecMocks(
+    overrides: Record<string, { error?: Error; stdout?: string }> = {},
+  ) {
+    const defaults: Record<string, { error?: Error; stdout?: string }> = {
+      'nvidia-smi': {
+        stdout: 'NVIDIA RTX 4090, 55, 42, 8192, 24576, 280, 450',
+      },
+      df: { stdout: '  Used  Size\n  120G  500G\n' },
+      ollama: {
+        stdout:
+          'NAME           ID       SIZE    PROCESSOR    UNTIL\nllama3:8b      abc123   4.7GB   100% GPU    Forever\n',
+      },
+      ...overrides,
+    }
+
+    mockedExecFile.mockImplementation(
+      (cmd: string, _args: unknown[], _opts: unknown, cb?: Function) => {
+        if (typeof _opts === 'function') cb = _opts
+        const mock = defaults[cmd]
+        if (mock?.error) {
+          cb!(mock.error)
+        } else if (mock) {
+          cb!(null, { stdout: mock.stdout })
+        } else {
+          cb!(new Error(`Unknown command: ${cmd}`))
+        }
+        return {}
+      },
+    )
+  }
+
+  describe('GET /system', () => {
+    it('returns full system resources on success', async () => {
+      setupProcMocks()
+      setupExecMocks()
+
+      const res = await app.request('/system')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      // CPU
+      expect(data.cpu).toBeDefined()
+      expect(data.cpu.cores).toBe(2)
+      expect(data.cpu.usagePercent).toBeGreaterThan(0)
+
+      // Memory
+      expect(data.memory).toBeDefined()
+      expect(data.memory.totalMB).toBeGreaterThan(0)
+      expect(data.memory.usedMB).toBeGreaterThan(0)
+
+      // GPU
+      expect(data.gpu).toBeDefined()
+      expect(data.gpu.name).toContain('RTX 4090')
+
+      // Disk
+      expect(data.disk).toBeDefined()
+      expect(data.disk.path).toBe('/')
+
+      // Uptime (90061s = 1d 1h 1m)
+      expect(data.uptime).toContain('d')
+
+      // Loaded models
+      expect(data.loadedModels).toBeDefined()
+    })
+
+    it('returns null GPU when nvidia-smi fails', async () => {
+      setupProcMocks()
+      setupExecMocks({
+        'nvidia-smi': { error: new Error('nvidia-smi not found') },
+      })
+
+      const res = await app.request('/system')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.gpu).toBeNull()
+    })
+
+    it('returns empty loaded models when ollama fails', async () => {
+      setupProcMocks()
+      setupExecMocks({
+        'nvidia-smi': { error: new Error('not found') },
+        ollama: { error: new Error('not found') },
+      })
+
+      const res = await app.request('/system')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.loadedModels).toEqual([])
+    })
+
+    it('returns fallback values when /proc files are unreadable', async () => {
+      mockedReadFile.mockRejectedValue(new Error('Permission denied'))
+      setupExecMocks({
+        'nvidia-smi': { error: new Error('not found') },
+        df: { error: new Error('not found') },
+        ollama: { error: new Error('not found') },
+      })
+
+      const res = await app.request('/system')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.cpu).toEqual({ usagePercent: 0, cores: 0 })
+      expect(data.memory).toEqual({ usedMB: 0, totalMB: 0 })
+      expect(data.disk).toEqual({ usedGB: 0, totalGB: 0, path: '/' })
+      expect(data.gpu).toBeNull()
+      expect(data.loadedModels).toEqual([])
+      expect(data.uptime).toBe('unknown')
+    })
+
+    it('formats uptime correctly for days', async () => {
+      // 2 days, 3 hours, 25 minutes = 2*86400 + 3*3600 + 25*60 = 184100 (actually use correct value)
+      // 2*86400 + 3*3600 + 25*60 = 172800 + 10800 + 1500 = 185100
+      setupProcMocks({ '/proc/uptime': '185100.00 300000.00' })
+      setupExecMocks({
+        'nvidia-smi': { error: new Error('not found') },
+        ollama: { error: new Error('not found') },
+      })
+
+      const res = await app.request('/system')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.uptime).toBe('2d 3h 25m')
+    })
+
+    it('formats uptime without days when under 24h', async () => {
+      // 5 hours, 30 minutes = 5*3600 + 30*60 = 19800
+      setupProcMocks({ '/proc/uptime': '19800.00 30000.00' })
+      setupExecMocks({
+        'nvidia-smi': { error: new Error('not found') },
+        ollama: { error: new Error('not found') },
+      })
+
+      const res = await app.request('/system')
+      expect(res.status).toBe(200)
+      const data = await res.json()
+
+      expect(data.uptime).toBe('5h 30m')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds unit tests for the 4 remaining untested server route handlers, completing the test coverage requested in #44.

## New Test Files

| File | Tests | Coverage |
|------|-------|----------|
| `knowledge.test.ts` | 22 | List/search/filter artifacts, single artifact retrieval with path traversal protection, stats aggregation |
| `interactions.test.ts` | 11 | Agent node building with name mapping, delegation edge inference, edge count accumulation, avg scores, error handling |
| `notifications.test.ts` | 7 | GET/DELETE endpoints, scanForEvents detecting high scores, crashes, low scores |
| `system.test.ts` | 6 | Full resource response, GPU/ollama failure fallbacks, /proc unreadable fallbacks, uptime formatting |

**Total: 46 new tests**

## Test Results

All 254 tests pass across all workspaces:
- shared: 39 passed
- server: 169 passed (was 123)
- client: 46 passed

## Acceptance Criteria

- [x] Test files created in `server/src/__tests__/`
- [x] Each route's endpoints are tested
- [x] Error handling paths are tested (file-not-found, parse errors, etc.)
- [x] All tests pass with `npm run test -w server`
- [x] No changes to source files (test-only PR)

Closes #44