### PR TITLE
test(client): add unit tests for page components

### DIFF
--- a/client/src/__tests__/Activity.test.tsx
+++ b/client/src/__tests__/Activity.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from './helpers'
+import { Activity } from '../pages/Activity'
+
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+vi.mock('@/hooks/useDemo', () => ({
+  useDemo: vi.fn(() => ({ isDemo: false })),
+}))
+
+// Mock fetch for react-query
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+import { useDemo } from '@/hooks/useDemo'
+const mockUseDemo = vi.mocked(useDemo)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseDemo.mockReturnValue({ isDemo: false })
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve([]),
+    ok: true,
+  })
+})
+
+describe('Activity', () => {
+  it('renders the activity log header', () => {
+    const { getByText } = renderWithProviders(<Activity />)
+    expect(getByText('ACTIVITY LOG')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', () => {
+    const { container } = renderWithProviders(<Activity />)
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Activity Log')
+  })
+
+  it('shows empty state when no log entries', () => {
+    const { getByText } = renderWithProviders(<Activity />)
+    expect(getByText('No activity yet.')).toBeTruthy()
+  })
+
+  it('shows empty state for artifacts', () => {
+    const { getByText } = renderWithProviders(<Activity />)
+    expect(getByText('No artifacts yet.')).toBeTruthy()
+  })
+
+  it('renders section headings', () => {
+    const { getByText } = renderWithProviders(<Activity />)
+    expect(getByText('Agent Log')).toBeTruthy()
+    expect(getByText('Recent Artifacts')).toBeTruthy()
+  })
+
+  it('renders cycle timeline in demo mode', () => {
+    mockUseDemo.mockReturnValue({ isDemo: true })
+    const { getByText } = renderWithProviders(<Activity />)
+    expect(getByText('Cycle Timeline')).toBeTruthy()
+  })
+
+  it('does not render cycle timeline when not in demo and no current cycle', () => {
+    mockUseDemo.mockReturnValue({ isDemo: false })
+    const { queryByText } = renderWithProviders(<Activity />)
+    expect(queryByText('Cycle Timeline')).toBeNull()
+  })
+})

--- a/client/src/__tests__/Cron.test.tsx
+++ b/client/src/__tests__/Cron.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from './helpers'
+import { Cron } from '../pages/Cron'
+import { fireEvent, waitFor } from '@testing-library/react'
+import type { CronJob } from '@tenshu/shared'
+
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+
+const mockJobs: CronJob[] = [
+  {
+    id: 'job-1',
+    name: 'Orchestrate Cycle',
+    schedule: '*/30 * * * *',
+    enabled: true,
+    lastRun: '2024-01-01T10:00:00Z',
+    nextRun: '2024-01-01T10:30:00Z',
+    lastStatus: 'success',
+  },
+  {
+    id: 'job-2',
+    name: 'Health Check',
+    schedule: '0 * * * *',
+    enabled: false,
+    lastStatus: 'error',
+  },
+]
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve(mockJobs),
+    ok: true,
+  })
+})
+
+describe('Cron', () => {
+  it('renders loading state initially', () => {
+    mockFetch.mockResolvedValue({
+      json: () => new Promise(() => {}),
+      ok: true,
+    })
+    const { getByText } = renderWithProviders(<Cron />)
+    expect(getByText('Loading cron jobs...')).toBeTruthy()
+  })
+
+  it('renders the scheduled ops header', async () => {
+    const { findByText } = renderWithProviders(<Cron />)
+    expect(await findByText('SCHEDULED OPS')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', async () => {
+    const { container, findByText } = renderWithProviders(<Cron />)
+    await findByText('SCHEDULED OPS')
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Scheduled Operations')
+  })
+
+  it('displays job names', async () => {
+    const { findByText } = renderWithProviders(<Cron />)
+    expect(await findByText('Orchestrate Cycle')).toBeTruthy()
+    expect(await findByText('Health Check')).toBeTruthy()
+  })
+
+  it('displays cron schedules', async () => {
+    const { findByText } = renderWithProviders(<Cron />)
+    expect(await findByText('*/30 * * * *')).toBeTruthy()
+    expect(await findByText('0 * * * *')).toBeTruthy()
+  })
+
+  it('displays last status badges', async () => {
+    const { findByText } = renderWithProviders(<Cron />)
+    expect(await findByText('success')).toBeTruthy()
+    expect(await findByText('error')).toBeTruthy()
+  })
+
+  it('shows paused badge for disabled jobs', async () => {
+    const { findByText } = renderWithProviders(<Cron />)
+    expect(await findByText('paused')).toBeTruthy()
+  })
+
+  it('shows empty state when no jobs', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve([]),
+      ok: true,
+    })
+    const { findByText } = renderWithProviders(<Cron />)
+    expect(await findByText('No cron jobs configured')).toBeTruthy()
+  })
+
+  it('calls toggle mutation when play/pause button is clicked', async () => {
+    const { findByText, container } = renderWithProviders(<Cron />)
+    await findByText('Orchestrate Cycle')
+    // Reset mock after initial data fetch calls
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(mockJobs),
+      ok: true,
+    })
+    // Find all buttons - first two per job (toggle + run)
+    const buttons = container.querySelectorAll('button')
+    expect(buttons.length).toBeGreaterThanOrEqual(2)
+    // Click the first toggle button (pause for enabled job)
+    fireEvent.click(buttons[0])
+    // Mutation fires asynchronously
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/cron/job-1',
+        expect.objectContaining({
+          method: 'PUT',
+        }),
+      )
+    })
+  })
+
+  it('calls run mutation when refresh button is clicked', async () => {
+    const { findByText, container } = renderWithProviders(<Cron />)
+    await findByText('Orchestrate Cycle')
+    // Reset mock after initial data fetch calls
+    mockFetch.mockClear()
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(mockJobs),
+      ok: true,
+    })
+    const buttons = container.querySelectorAll('button')
+    // Second button per job is the run button
+    fireEvent.click(buttons[1])
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/cron/job-1/run',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      )
+    })
+  })
+})

--- a/client/src/__tests__/Dashboard.test.tsx
+++ b/client/src/__tests__/Dashboard.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders, makeAgent } from './helpers'
+import { Dashboard } from '../pages/Dashboard'
+
+// Mock hooks
+vi.mock('@/hooks/useAgents', () => ({
+  useAgents: vi.fn(() => ({ agents: [], loading: false, connected: true })),
+}))
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+vi.mock('@/hooks/useAgentHistory', () => ({
+  useAgentHistory: vi.fn(() => ({ data: {} })),
+}))
+vi.mock('@/hooks/usePowerLevel', () => ({
+  usePowerLevel: vi.fn(() => ({
+    xp: 0,
+    level: 0,
+    levelName: 'Genin',
+    nextLevelXp: 500,
+    progress: 0,
+    powerLevel: 0,
+  })),
+}))
+vi.mock('@/hooks/useAchievements', () => ({
+  useAchievements: vi.fn(() => []),
+}))
+vi.mock('@/hooks/useDemo', () => ({
+  useDemo: vi.fn(() => ({ isDemo: true })),
+}))
+vi.mock('@/hooks/useMockData', () => ({
+  useMockResults: vi.fn(() => ({ data: [], isLoading: false })),
+}))
+import { useMockResults } from '@/hooks/useMockData'
+vi.mock('@/components/ActivityFeed', () => ({
+  ActivityFeed: () => <div data-testid="activity-feed">ActivityFeed</div>,
+}))
+
+import { useAgents } from '@/hooks/useAgents'
+import { useAchievements } from '@/hooks/useAchievements'
+const mockUseAgents = vi.mocked(useAgents)
+const mockUseAchievements = vi.mocked(useAchievements)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseAgents.mockReturnValue({ agents: [], loading: false, connected: true })
+  mockUseAchievements.mockReturnValue([])
+})
+
+describe('Dashboard', () => {
+  it('renders loading state', () => {
+    mockUseAgents.mockReturnValue({
+      agents: [],
+      loading: true,
+      connected: false,
+    })
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('Loading agents...')).toBeTruthy()
+  })
+
+  it('renders the overview header', () => {
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('OVERVIEW')).toBeTruthy()
+  })
+
+  it('shows connected status when connected', () => {
+    mockUseAgents.mockReturnValue({
+      agents: [],
+      loading: false,
+      connected: true,
+    })
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('Connected')).toBeTruthy()
+    expect(getByText('Live')).toBeTruthy()
+  })
+
+  it('shows disconnected status when not connected', () => {
+    mockUseAgents.mockReturnValue({
+      agents: [],
+      loading: false,
+      connected: false,
+    })
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('Disconnected')).toBeTruthy()
+    expect(getByText('Offline')).toBeTruthy()
+  })
+
+  it('renders agent cards for each agent', () => {
+    const agents = [
+      makeAgent({ config: { id: 'coder-bulma', name: 'Bulma' } }),
+      makeAgent({ config: { id: 'qa-vegeta', name: 'Vegeta' } }),
+    ]
+    mockUseAgents.mockReturnValue({ agents, loading: false, connected: true })
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('Bulma')).toBeTruthy()
+    expect(getByText('Vegeta')).toBeTruthy()
+  })
+
+  it('shows empty state when no agents configured', () => {
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('No agents configured in openclaw.json')).toBeTruthy()
+  })
+
+  it('displays correct active agent count', () => {
+    const agents = [
+      makeAgent({
+        config: { id: 'coder-a', name: 'A' },
+        state: { status: 'working' },
+      }),
+      makeAgent({
+        config: { id: 'qa-b', name: 'B' },
+        state: { status: 'idle' },
+      }),
+      makeAgent({
+        config: { id: 'researcher-c', name: 'C' },
+        state: { status: 'thinking' },
+      }),
+    ]
+    mockUseAgents.mockReturnValue({ agents, loading: false, connected: true })
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('2/3')).toBeTruthy()
+  })
+
+  it('renders achievements when results exist', () => {
+    vi.mocked(useMockResults).mockReturnValue({
+      data: [
+        {
+          timestamp: '2024-01-01',
+          cycle: 1,
+          task: 'test',
+          agent: 'a',
+          score: 8,
+          status: 'keep',
+          description: 'test',
+        },
+      ],
+      isLoading: false,
+    })
+    mockUseAchievements.mockReturnValue([
+      {
+        id: 'first-win',
+        name: 'First Win',
+        description: 'Win your first battle',
+        icon: '🏆',
+        unlocked: true,
+      },
+      {
+        id: 'streak',
+        name: 'Hot Streak',
+        description: 'Win 5 in a row',
+        icon: '🔥',
+        unlocked: false,
+      },
+    ])
+    const { getByText } = renderWithProviders(<Dashboard />)
+    expect(getByText('First Win')).toBeTruthy()
+    expect(getByText('Hot Streak')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', () => {
+    const { container } = renderWithProviders(<Dashboard />)
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Dashboard Overview')
+  })
+})

--- a/client/src/__tests__/Interactions.test.tsx
+++ b/client/src/__tests__/Interactions.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from './helpers'
+import { Interactions } from '../pages/Interactions'
+
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+vi.mock('@/hooks/useDemo', () => ({
+  useDemo: vi.fn(() => ({ isDemo: true })),
+}))
+
+// Mock canvas getContext since jsdom doesn't support canvas
+const mockCtx = {
+  clearRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+  fill: vi.fn(),
+  closePath: vi.fn(),
+  arc: vi.fn(),
+  fillText: vi.fn(),
+  strokeStyle: '',
+  fillStyle: '',
+  lineWidth: 0,
+  font: '',
+  textAlign: '',
+  textBaseline: '',
+  globalAlpha: 1,
+  shadowColor: '',
+  shadowBlur: 0,
+}
+HTMLCanvasElement.prototype.getContext = vi.fn(
+  () => mockCtx,
+) as unknown as typeof HTMLCanvasElement.prototype.getContext
+
+// Mock requestAnimationFrame to run once then stop (prevent infinite loop)
+let rafCallCount = 0
+vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
+  rafCallCount++
+  if (rafCallCount <= 1) {
+    cb(0)
+  }
+  return rafCallCount
+})
+vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  rafCallCount = 0
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve({ nodes: [], edges: [] }),
+    ok: true,
+  })
+})
+
+describe('Interactions', () => {
+  it('renders the interaction map header', () => {
+    const { getByText } = renderWithProviders(<Interactions />)
+    expect(getByText('INTERACTION MAP')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', () => {
+    const { container } = renderWithProviders(<Interactions />)
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Interaction Map')
+  })
+
+  it('displays stats cards with demo data', () => {
+    const { getByText, getAllByText } = renderWithProviders(<Interactions />)
+    expect(getByText('Agents')).toBeTruthy()
+    // 5 appears in both Agents and Connections cards
+    expect(getAllByText('5').length).toBe(2)
+    expect(getByText('Delegations')).toBeTruthy()
+    expect(getByText('568')).toBeTruthy()
+    expect(getByText('Connections')).toBeTruthy()
+    expect(getByText('Avg Score')).toBeTruthy()
+    expect(getByText('6.4')).toBeTruthy()
+  })
+
+  it('renders the delegation flow section', () => {
+    const { getByText } = renderWithProviders(<Interactions />)
+    expect(getByText('Agent Delegation Flow')).toBeTruthy()
+  })
+
+  it('renders role color legend', () => {
+    const { getAllByText } = renderWithProviders(<Interactions />)
+    // Role labels appear in both the legend and delegation details table
+    expect(getAllByText('planner').length).toBeGreaterThan(0)
+    expect(getAllByText('researcher').length).toBeGreaterThan(0)
+    expect(getAllByText('coder').length).toBeGreaterThan(0)
+    expect(getAllByText('qa').length).toBeGreaterThan(0)
+    expect(getAllByText('comms').length).toBeGreaterThan(0)
+  })
+
+  it('renders delegation details table in demo mode', () => {
+    const { getByText } = renderWithProviders(<Interactions />)
+    expect(getByText('Delegation Details')).toBeTruthy()
+  })
+
+  it('renders canvas element for graph', () => {
+    const { container } = renderWithProviders(<Interactions />)
+    const canvas = container.querySelector('canvas')
+    expect(canvas).not.toBeNull()
+  })
+})

--- a/client/src/__tests__/Knowledge.test.tsx
+++ b/client/src/__tests__/Knowledge.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from './helpers'
+import { Knowledge } from '../pages/Knowledge'
+import { fireEvent } from '@testing-library/react'
+
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+vi.mock('@/hooks/useDemo', () => ({
+  useDemo: vi.fn(() => ({ isDemo: true })),
+}))
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve([]),
+    ok: true,
+  })
+})
+
+describe('Knowledge', () => {
+  it('renders the knowledge base header', () => {
+    const { getByText } = renderWithProviders(<Knowledge />)
+    expect(getByText('KNOWLEDGE BASE')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', () => {
+    const { container } = renderWithProviders(<Knowledge />)
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Knowledge Base')
+  })
+
+  it('displays stats cards in demo mode', () => {
+    const { getByText } = renderWithProviders(<Knowledge />)
+    expect(getByText('Artifacts')).toBeTruthy()
+    expect(getByText('30')).toBeTruthy()
+    expect(getByText('Total Size')).toBeTruthy()
+    expect(getByText('332KB')).toBeTruthy()
+  })
+
+  it('renders search input with correct placeholder', () => {
+    const { container } = renderWithProviders(<Knowledge />)
+    const input = container.querySelector('input[type="text"]')
+    expect(input).not.toBeNull()
+    expect(input?.getAttribute('placeholder')).toBe('Search artifacts...')
+  })
+
+  it('renders type filter buttons', () => {
+    const { container } = renderWithProviders(<Knowledge />)
+    const filterArea = container.querySelector('[role="search"]')
+    expect(filterArea).not.toBeNull()
+    const buttons = filterArea!.querySelectorAll('button')
+    const buttonTexts = Array.from(buttons).map((b) => b.textContent)
+    expect(buttonTexts).toContain('All')
+    expect(buttonTexts).toContain('research')
+    expect(buttonTexts).toContain('coder')
+    expect(buttonTexts).toContain('qa')
+  })
+
+  it('shows artifact count', () => {
+    const { getByText } = renderWithProviders(<Knowledge />)
+    expect(getByText(/30 of 30 artifacts/)).toBeTruthy()
+  })
+
+  it('renders demo artifacts in grid', () => {
+    const { container } = renderWithProviders(<Knowledge />)
+    // Demo generates 30 artifacts, each in a ThemedCard
+    const badges = container.querySelectorAll('[class*="badge"]')
+    expect(badges.length).toBeGreaterThan(0)
+  })
+
+  it('filters artifacts by type when filter button clicked', () => {
+    const { container, getByText } = renderWithProviders(<Knowledge />)
+    const filterArea = container.querySelector('[role="search"]')
+    const researchBtn = Array.from(filterArea!.querySelectorAll('button')).find(
+      (b) => b.textContent === 'research',
+    )
+    expect(researchBtn).toBeTruthy()
+    fireEvent.click(researchBtn!)
+    expect(getByText(/10 of 30 artifacts/)).toBeTruthy()
+  })
+
+  it('opens artifact detail when artifact is clicked', () => {
+    const { container, getByText } = renderWithProviders(<Knowledge />)
+    // Click first artifact card
+    const cards = container.querySelectorAll('.cursor-pointer')
+    if (cards[0]) {
+      fireEvent.click(cards[0])
+      // Should show Close button when detail is open
+      expect(getByText('Close')).toBeTruthy()
+    }
+  })
+
+  it('closes artifact detail when close button clicked', () => {
+    const { container, getByText, queryByText } = renderWithProviders(
+      <Knowledge />,
+    )
+    const cards = container.querySelectorAll('.cursor-pointer')
+    if (cards[0]) {
+      fireEvent.click(cards[0])
+      expect(getByText('Close')).toBeTruthy()
+      fireEvent.click(getByText('Close'))
+      expect(queryByText('Close')).toBeNull()
+    }
+  })
+})

--- a/client/src/__tests__/Office.test.tsx
+++ b/client/src/__tests__/Office.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders, makeAgent } from './helpers'
+import { Office } from '../pages/Office'
+
+vi.mock('@/hooks/useAgents', () => ({
+  useAgents: vi.fn(() => ({ agents: [], loading: false, connected: true })),
+}))
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+vi.mock('@/hooks/useSound', () => ({
+  useSoundOnStatusChange: vi.fn(),
+  useSound: vi.fn(() => ({ play: vi.fn(), muted: false, setMuted: vi.fn() })),
+}))
+vi.mock('@/office2d/WarRoom', () => ({
+  WarRoom: ({ agents }: { agents: unknown[] }) => (
+    <div data-testid="war-room">WarRoom ({agents.length} agents)</div>
+  ),
+}))
+vi.mock('@/office2d/ControlDeck', () => ({
+  ControlDeck: ({ agents }: { agents: unknown[] }) => (
+    <div data-testid="control-deck">ControlDeck ({agents.length} agents)</div>
+  ),
+}))
+vi.mock('@/office2d/GardenView', () => ({
+  GardenView: ({ agents }: { agents: unknown[] }) => (
+    <div data-testid="garden-view">GardenView ({agents.length} agents)</div>
+  ),
+}))
+vi.mock('@/office2d/AgentPanel', () => ({
+  default: ({ agent }: { agent: { config: { name: string } } }) => (
+    <div data-testid="agent-panel">Panel: {agent.config.name}</div>
+  ),
+}))
+
+import { useAgents } from '@/hooks/useAgents'
+import { useTheme } from '@/hooks/useTheme'
+const mockUseAgents = vi.mocked(useAgents)
+const mockUseTheme = vi.mocked(useTheme)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseAgents.mockReturnValue({ agents: [], loading: false, connected: true })
+  mockUseTheme.mockReturnValue({ theme: 'warroom', setTheme: vi.fn() })
+})
+
+describe('Office', () => {
+  it('renders loading state', () => {
+    mockUseAgents.mockReturnValue({
+      agents: [],
+      loading: true,
+      connected: false,
+    })
+    const { getByText } = renderWithProviders(<Office />)
+    expect(getByText('Loading...')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', () => {
+    const { container } = renderWithProviders(<Office />)
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Command Center')
+  })
+
+  it('renders WarRoom when theme is warroom', () => {
+    mockUseTheme.mockReturnValue({ theme: 'warroom', setTheme: vi.fn() })
+    const { getByTestId } = renderWithProviders(<Office />)
+    expect(getByTestId('war-room')).toBeTruthy()
+  })
+
+  it('renders ControlDeck when theme is deck', () => {
+    mockUseTheme.mockReturnValue({ theme: 'deck', setTheme: vi.fn() })
+    const { getByTestId } = renderWithProviders(<Office />)
+    expect(getByTestId('control-deck')).toBeTruthy()
+  })
+
+  it('renders GardenView when theme is garden', () => {
+    mockUseTheme.mockReturnValue({ theme: 'garden', setTheme: vi.fn() })
+    const { getByTestId } = renderWithProviders(<Office />)
+    expect(getByTestId('garden-view')).toBeTruthy()
+  })
+
+  it('passes agents to the theme view', () => {
+    const agents = [
+      makeAgent({ config: { id: 'coder-a', name: 'Agent A' } }),
+      makeAgent({ config: { id: 'qa-b', name: 'Agent B' } }),
+    ]
+    mockUseAgents.mockReturnValue({ agents, loading: false, connected: true })
+    const { getByText } = renderWithProviders(<Office />)
+    expect(getByText('WarRoom (2 agents)')).toBeTruthy()
+  })
+
+  it('does not show agent panel when no agent is selected', () => {
+    const { queryByTestId } = renderWithProviders(<Office />)
+    expect(queryByTestId('agent-panel')).toBeNull()
+  })
+})

--- a/client/src/__tests__/Results.test.tsx
+++ b/client/src/__tests__/Results.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from './helpers'
+import { Results } from '../pages/Results'
+import { fireEvent } from '@testing-library/react'
+
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+vi.mock('@/hooks/useDemo', () => ({
+  useDemo: vi.fn(() => ({ isDemo: true })),
+}))
+vi.mock('@/hooks/useMockData', () => ({
+  useMockResults: vi.fn(() => ({
+    data: [
+      {
+        timestamp: '2024-01-01T00:00:00Z',
+        cycle: 1,
+        task: 'code-review',
+        agent: 'Bulma',
+        score: 8.5,
+        status: 'keep',
+        description: 'Reviewed PR #42',
+      },
+      {
+        timestamp: '2024-01-01T01:00:00Z',
+        cycle: 2,
+        task: 'tool-building',
+        agent: 'Senku',
+        score: 4.0,
+        status: 'discard',
+        description: 'Built a tool',
+      },
+      {
+        timestamp: '2024-01-01T02:00:00Z',
+        cycle: 3,
+        task: 'code-review',
+        agent: 'Bulma',
+        score: 9.0,
+        status: 'keep',
+        description: 'Another review',
+      },
+    ],
+    isLoading: false,
+  })),
+}))
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve([]),
+    ok: true,
+  })
+})
+
+describe('Results', () => {
+  it('renders the battle record header', () => {
+    const { getByText } = renderWithProviders(<Results />)
+    expect(getByText('BATTLE RECORD')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', () => {
+    const { container } = renderWithProviders(<Results />)
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Results')
+  })
+
+  it('displays stats cards with correct values', () => {
+    const { getByText } = renderWithProviders(<Results />)
+    // Total Cycles
+    expect(getByText('Total Cycles')).toBeTruthy()
+    expect(getByText('3')).toBeTruthy()
+    // Kept
+    expect(getByText('Kept')).toBeTruthy()
+    expect(getByText('2')).toBeTruthy()
+    // Success Rate
+    expect(getByText('Success Rate')).toBeTruthy()
+    expect(getByText('67%')).toBeTruthy()
+  })
+
+  it('shows agent filter buttons', () => {
+    const { getAllByText } = renderWithProviders(<Results />)
+    expect(getAllByText('all').length).toBeGreaterThan(0)
+    expect(getAllByText('Bulma').length).toBeGreaterThan(0)
+    expect(getAllByText('Senku').length).toBeGreaterThan(0)
+  })
+
+  it('filters results by agent when filter clicked', () => {
+    const { container } = renderWithProviders(<Results />)
+    // Find the filter buttons area (gap-1 container)
+    const filterButtons = container.querySelectorAll(
+      '.flex.items-center.gap-1 button',
+    )
+    // Click the "Bulma" filter (second button after "all")
+    const bulmaBtn = Array.from(filterButtons).find(
+      (b) => b.textContent === 'Bulma',
+    )
+    expect(bulmaBtn).toBeTruthy()
+    fireEvent.click(bulmaBtn!)
+    // After filtering to Bulma, should see Bulma's results only
+    const rows = container.querySelectorAll('tbody tr')
+    expect(rows.length).toBe(2)
+  })
+
+  it('renders results table with correct columns', () => {
+    const { getByText } = renderWithProviders(<Results />)
+    expect(getByText('Time')).toBeTruthy()
+    expect(getByText('Cycle')).toBeTruthy()
+    expect(getByText('Task')).toBeTruthy()
+    expect(getByText('Agent')).toBeTruthy()
+    expect(getByText('Score')).toBeTruthy()
+    expect(getByText('Status')).toBeTruthy()
+    expect(getByText('Description')).toBeTruthy()
+  })
+
+  it('renders score trend chart', () => {
+    const { getByText } = renderWithProviders(<Results />)
+    expect(getByText(/Score Trend/)).toBeTruthy()
+  })
+
+  it('renders task type performance breakdown', () => {
+    const { getByText } = renderWithProviders(<Results />)
+    expect(getByText('Task Type Performance')).toBeTruthy()
+  })
+})

--- a/client/src/__tests__/Sessions.test.tsx
+++ b/client/src/__tests__/Sessions.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from './helpers'
+import { Sessions } from '../pages/Sessions'
+import type { Session } from '@tenshu/shared'
+
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+
+const mockSessions: Session[] = [
+  {
+    id: 'sess-1',
+    agentId: 'coder-bulma',
+    label: 'Code review',
+    startedAt: '2024-01-01T10:00:00Z',
+    lastActivity: '2024-01-01T10:30:00Z',
+    inputTokens: 5000,
+    outputTokens: 3000,
+    totalTokens: 8000,
+    model: 'gpt-4o',
+    cost: 0.0234,
+  },
+  {
+    id: 'sess-2',
+    agentId: 'qa-vegeta',
+    startedAt: '2024-01-01T11:00:00Z',
+    lastActivity: '2024-01-01T11:15:00Z',
+    inputTokens: 2000,
+    outputTokens: 1000,
+    totalTokens: 3000,
+    model: 'claude-3.5-sonnet',
+    cost: 0.0089,
+  },
+]
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve(mockSessions),
+    ok: true,
+  })
+})
+
+describe('Sessions', () => {
+  it('renders loading state initially', () => {
+    mockFetch.mockResolvedValue({
+      json: () => new Promise(() => {}),
+      ok: true,
+    })
+    const { getByText } = renderWithProviders(<Sessions />)
+    expect(getByText('Loading sessions...')).toBeTruthy()
+  })
+
+  it('renders the sessions header', async () => {
+    const { findByText } = renderWithProviders(<Sessions />)
+    expect(await findByText('SESSIONS')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', async () => {
+    const { container, findByText } = renderWithProviders(<Sessions />)
+    await findByText('SESSIONS')
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('Sessions')
+  })
+
+  it('displays stats cards with totals', async () => {
+    const { findByText } = renderWithProviders(<Sessions />)
+    expect(await findByText('Active')).toBeTruthy()
+    expect(await findByText('Total Cost')).toBeTruthy()
+    expect(await findByText('Tokens')).toBeTruthy()
+  })
+
+  it('displays session agent IDs', async () => {
+    const { findByText } = renderWithProviders(<Sessions />)
+    expect(await findByText('coder-bulma')).toBeTruthy()
+    expect(await findByText('qa-vegeta')).toBeTruthy()
+  })
+
+  it('displays session labels when present', async () => {
+    const { findByText } = renderWithProviders(<Sessions />)
+    expect(await findByText('Code review')).toBeTruthy()
+  })
+
+  it('displays session models', async () => {
+    const { findByText } = renderWithProviders(<Sessions />)
+    expect(await findByText('gpt-4o')).toBeTruthy()
+    expect(await findByText('claude-3.5-sonnet')).toBeTruthy()
+  })
+
+  it('shows empty state when no sessions', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve([]),
+      ok: true,
+    })
+    const { findByText } = renderWithProviders(<Sessions />)
+    expect(await findByText('No active sessions')).toBeTruthy()
+  })
+
+  it('displays token breakdown per session', async () => {
+    const { findByText } = renderWithProviders(<Sessions />)
+    expect(await findByText(/In: 5,000/)).toBeTruthy()
+    expect(await findByText(/Out: 3,000/)).toBeTruthy()
+  })
+})

--- a/client/src/__tests__/System.test.tsx
+++ b/client/src/__tests__/System.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithProviders } from './helpers'
+import { System } from '../pages/System'
+import type { SystemResources } from '@tenshu/shared'
+
+vi.mock('@/hooks/useTheme', async () => {
+  const actual = await vi.importActual('@/hooks/useTheme')
+  return {
+    ...actual,
+    useTheme: vi.fn(() => ({ theme: 'warroom', setTheme: vi.fn() })),
+  }
+})
+
+const mockSystemData: SystemResources = {
+  gpu: {
+    name: 'RTX 4090',
+    tempC: 65,
+    utilPercent: 75,
+    memUsedMB: 16000,
+    memTotalMB: 24000,
+    powerW: 250,
+    powerCapW: 450,
+  },
+  cpu: {
+    usagePercent: 45,
+    cores: 16,
+  },
+  memory: {
+    usedMB: 24000,
+    totalMB: 64000,
+  },
+  disk: {
+    usedGB: 500,
+    totalGB: 2000,
+    path: '/',
+  },
+  loadedModels: [
+    { name: 'qwen2.5-coder:32b', sizeGB: 18 },
+    { name: 'llama3:8b', sizeGB: 4.7 },
+  ],
+  uptime: '3d 14h 22m',
+}
+
+// Mock fetch
+const mockFetch = vi.fn()
+globalThis.fetch = mockFetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockFetch.mockResolvedValue({
+    json: () => Promise.resolve(mockSystemData),
+    ok: true,
+  })
+})
+
+describe('System', () => {
+  it('renders loading state when data is not available', () => {
+    mockFetch.mockResolvedValue({
+      json: () => new Promise(() => {}), // never resolves
+      ok: true,
+    })
+    const { getByText } = renderWithProviders(<System />)
+    expect(getByText('Loading system info...')).toBeTruthy()
+  })
+
+  it('renders the instruments header', async () => {
+    const { findByText } = renderWithProviders(<System />)
+    expect(await findByText('INSTRUMENTS')).toBeTruthy()
+  })
+
+  it('renders sr-only heading for accessibility', async () => {
+    const { container, findByText } = renderWithProviders(<System />)
+    await findByText('INSTRUMENTS')
+    const srHeading = container.querySelector('.sr-only')
+    expect(srHeading?.textContent).toBe('System Instruments')
+  })
+
+  it('displays uptime badge', async () => {
+    const { findByText } = renderWithProviders(<System />)
+    expect(await findByText(/3d 14h 22m/)).toBeTruthy()
+  })
+
+  it('displays GPU information', async () => {
+    const { findByText } = renderWithProviders(<System />)
+    expect(await findByText('RTX 4090')).toBeTruthy()
+    expect(await findByText('65°C')).toBeTruthy()
+  })
+
+  it('displays CPU core count', async () => {
+    const { findByText } = renderWithProviders(<System />)
+    expect(await findByText('16 cores')).toBeTruthy()
+  })
+
+  it('displays loaded models', async () => {
+    const { findByText } = renderWithProviders(<System />)
+    expect(await findByText('qwen2.5-coder:32b')).toBeTruthy()
+    expect(await findByText('llama3:8b')).toBeTruthy()
+    expect(await findByText('18GB')).toBeTruthy()
+  })
+
+  it('renders without GPU section when gpu is null', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ ...mockSystemData, gpu: null }),
+      ok: true,
+    })
+    const { findByText, queryByText } = renderWithProviders(<System />)
+    await findByText('INSTRUMENTS')
+    expect(queryByText('RTX 4090')).toBeNull()
+  })
+
+  it('shows no models loaded message when models list is empty', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ ...mockSystemData, loadedModels: [] }),
+      ok: true,
+    })
+    const { findByText } = renderWithProviders(<System />)
+    expect(await findByText('No models loaded')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Closes #23

## What

Added unit tests for all 9 client page components:

| Page Component | Tests | Coverage |
|---|---|---|
| Dashboard.tsx | 9 | Loading, header, connected/disconnected agents, agent cards, empty state, active count, achievements, a11y |
| Activity.tsx | 7 | Header, a11y, empty states (log/artifacts), section headings, cycle timeline in demo/non-demo |
| Results.tsx | 8 | Header, a11y, stats cards, agent filter buttons, filtering, table columns, score trend, task breakdown |
| Knowledge.tsx | 10 | Header, a11y, stats, search input, type filters, artifact count, demo artifacts, filtering, detail open/close |
| System.tsx | 9 | Loading, header, a11y, uptime, GPU info, CPU cores, loaded models, no GPU, empty models |
| Interactions.tsx | 7 | Header, a11y, stats cards, delegation flow, role legend, delegation details, canvas |
| Office.tsx | 7 | Loading, a11y, theme-based view switching (warroom/deck/garden), agent passing, no panel when unselected |
| Sessions.tsx | 9 | Loading, header, a11y, stats, agent IDs, labels, models, empty state, token breakdown |
| Cron.tsx | 10 | Loading, header, a11y, job names, schedules, status badges, paused badge, empty state, toggle/run mutations |

## Details

- **76 new tests** across 9 test files (1077 lines)
- Uses existing `renderWithProviders` helper from `helpers.tsx`
- Mocks fetch, WebSocket, React Router, and custom hooks as needed
- Tests rendering, key UI elements, conditional rendering, and user interactions
- All tests pass: `npm run test -w client` → 122/122 ✅
- TypeScript clean: `npx tsc --noEmit` → 0 errors
- No source file changes — test-only PR